### PR TITLE
product category drop down works and shows error

### DIFF
--- a/Bangazon/Views/Products/Create.cshtml
+++ b/Bangazon/Views/Products/Create.cshtml
@@ -48,7 +48,8 @@
             </div>
             <div class="form-group">
                 <label asp-for="ProductTypeId" class="control-label"></label>
-                <select asp-for="ProductTypeId" class ="form-control" asp-items="ViewBag.ProductTypeId"></select>
+                <select asp-for="ProductTypeId" class="form-control" asp-items="ViewBag.ProductTypeId"><option></option></select>
+                <span asp-validation-for="ProductTypeId" class="text-danger"></span>
             </div>
             <div class="form-group">
                 <input type="submit" value="Create" class="btn btn-primary" />

--- a/Bangazon/Views/Shared/_Layout.cshtml
+++ b/Bangazon/Views/Shared/_Layout.cshtml
@@ -30,7 +30,7 @@
                     <partial name="_LoginPartial" />
                     <ul class="navbar-nav flex-grow-1">
                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Index">Home</a>
+                            <a class="nav-link text-dark" asp-area="" asp-controller="Products" asp-action="Index">Home</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-controller="ProductTypes" asp-action="Index">Product Types</a>


### PR DESCRIPTION
#Description
When you click the Sell Something link and create a new product, the product category drop down should should not show a category until clicked. If a product is saved when no category is selected there should be an error message. User should be able to see all categories when clicked.

Bug fix (non-breaking change which fixes an issue)
 
#Testing Instructions for Change Made
git fetch --all
git checkout viewCategories
dotnet run
verify...

#Checklist:
* My code follows the style guidelines of this project
 *I have performed a self-review of my own code
 *I have commented my code, particularly in hard-to-understand areas
 *My changes generate no new warnings
 *I have added test instructions that prove my fix is effective or that my feature works
