### PR TITLE
Add payment type

### DIFF
--- a/Bangazon/Models/PaymentType.cs
+++ b/Bangazon/Models/PaymentType.cs
@@ -18,18 +18,19 @@ namespace Bangazon.Models
 
     [Required]
     [StringLength(55)]
+    [Display(Name = "Card Type")]
     public string Description { get; set; }
 
     [Required]
     [StringLength(20)]
     public string AccountNumber { get; set; }
 
-    [Required]
-    public string UserId {get; set;}
+        //[Required]
+        public string UserId { get; set; }
 
-    [Required]
-    public ApplicationUser User { get; set; }
+        //[Required]
+        public ApplicationUser User { get; set; }
 
-    public ICollection<Order> Orders { get; set; }
+        public ICollection<Order> Orders { get; set; }
   }
 }

--- a/Bangazon/Models/Product.cs
+++ b/Bangazon/Models/Product.cs
@@ -37,7 +37,7 @@ namespace Bangazon.Models
 
     public string ImagePath {get; set;}
 
-    [Required]
+    //[Required]
     public ApplicationUser User { get; set; }
 
     [Required]

--- a/Bangazon/Views/Orders/Index.cshtml
+++ b/Bangazon/Views/Orders/Index.cshtml
@@ -9,6 +9,9 @@
 <p>
     <a asp-action="Create">Create New</a>
 </p>
+<p>
+    <a asp-controller="PaymentTypes" asp-action="Create">Create New Payment Type</a>
+</p>
 <table class="table">
     <thead>
         <tr>

--- a/Bangazon/Views/PaymentTypes/Create.cshtml
+++ b/Bangazon/Views/PaymentTypes/Create.cshtml
@@ -22,10 +22,10 @@
                 <input asp-for="AccountNumber" class="form-control" />
                 <span asp-validation-for="AccountNumber" class="text-danger"></span>
             </div>
-            <div class="form-group">
+            @*<div class="form-group" hidden>
                 <label asp-for="UserId" class="control-label"></label>
                 <select asp-for="UserId" class ="form-control" asp-items="ViewBag.UserId"></select>
-            </div>
+            </div>*@
             <div class="form-group">
                 <input type="submit" value="Create" class="btn btn-primary" />
             </div>

--- a/Bangazon/Views/Products/Create.cshtml
+++ b/Bangazon/Views/Products/Create.cshtml
@@ -48,7 +48,7 @@
             </div>
             <div class="form-group">
                 <label asp-for="ProductTypeId" class="control-label"></label>
-                <select asp-for="ProductTypeId" class="form-control" asp-items="ViewBag.ProductTypeId"><option></option></select>
+                <select asp-for="ProductTypeId" class="form-control" asp-items="ViewBag.ProductTypeId"><option value="">--Select Category--</option></select>
                 <span asp-validation-for="ProductTypeId" class="text-danger"></span>
             </div>
             <div class="form-group">

--- a/Bangazon/Views/Products/Create.cshtml
+++ b/Bangazon/Views/Products/Create.cshtml
@@ -48,7 +48,8 @@
             </div>
             <div class="form-group">
                 <label asp-for="ProductTypeId" class="control-label"></label>
-                <select asp-for="ProductTypeId" class ="form-control" asp-items="ViewBag.ProductTypeId"></select>
+                <select asp-for="ProductTypeId" class="form-control" asp-items="ViewBag.ProductTypeId"><option></option></select>
+                <span asp-validation-for="ProductTypeId" class="text-danger"></span>
             </div>
             <div class="form-group">
                 <input type="submit" value="Create" class="btn btn-primary" />

--- a/Bangazon/Views/Shared/_Layout.cshtml
+++ b/Bangazon/Views/Shared/_Layout.cshtml
@@ -30,7 +30,7 @@
                     <partial name="_LoginPartial" />
                     <ul class="navbar-nav flex-grow-1">
                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Index">Home</a>
+                            <a class="nav-link text-dark" asp-area="" asp-controller="Products" asp-action="Index">Home</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-controller="ProductTypes" asp-action="Index">Product Types</a>


### PR DESCRIPTION
#Description
When you click the Sell Something link and create a new product, the product category drop down should should not show a category until clicked. If a product is saved when no category is selected there should be an error message. User should be able to see all categories when clicked.

To create a new payment type click "view cart" in the nav bar and then the "create new payment type" link. Fill out the forms and click create. It should take you to a paymentTypes index page showing all your payments.

Bug fix (non-breaking change which fixes an issue)

#Testing Instructions for Change Made
git fetch --all
git checkout viewCategories
dotnet run
verify...

#Checklist:

My code follows the style guidelines of this project
*I have performed a self-review of my own code
*I have commented my code, particularly in hard-to-understand areas
*My changes generate no new warnings
*I have added test instructions that prove my fix is effective or that my feature works